### PR TITLE
Add truncated octohedron infill, use for really sparse infill

### DIFF
--- a/src/fffProcessor.h
+++ b/src/fffProcessor.h
@@ -636,7 +636,7 @@ private:
                         generateAutomaticInfill(
                             part->sparseOutline, fillPolygons, extrusionWidth,
                             config.sparseInfillLineDistance,
-                            config.infillOverlap, fillAngle);
+                            config.infillOverlap, fillAngle, layer->printZ);
                         break;
 
                     case INFILL_GRID:

--- a/src/infill.cpp
+++ b/src/infill.cpp
@@ -1,5 +1,11 @@
 /** Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License */
 #include "infill.h"
+#include <clipper/clipper.hpp>
+
+// sqrt(2) helpers for truncated octahedron calculations
+#define SQRT2MUL(x) ((30547*(x))/21600)
+#define OCTSLEN(x) ((43200*(x))/73747)
+#define OCTDLEN(x) ((21600*(x))/30547)
 
 namespace cura {
 
@@ -18,8 +24,13 @@ void generateConcentricInfill(Polygons outline, Polygons& result, int inset_valu
 
 void generateAutomaticInfill(const Polygons& in_outline, Polygons& result,
                              int extrusionWidth, int lineSpacing,
-                             int infillOverlap, double rotation)
+                             int infillOverlap, double rotation, int posZ)
 {
+    if (lineSpacing > extrusionWidth * 6)
+    {
+        generateTroctInfill(in_outline, result, extrusionWidth, lineSpacing,
+                           infillOverlap, rotation, posZ);
+    }
     if (lineSpacing > extrusionWidth * 4)
     {
         generateGridInfill(in_outline, result, extrusionWidth, lineSpacing,
@@ -101,6 +112,112 @@ void generateLineInfill(const Polygons& in_outline, Polygons& result, int extrus
             p.add(matrix.unapply(Point(x, cutList[idx][i+1])));
         }
         idx += 1;
+    }
+}
+
+  void generateTroctInfill(const Polygons& in_outline, Polygons& result, int extrusionWidth, int lineSpacing, int infillOverlap, double rotation, int posZ)
+  {
+    Polygons outline = in_outline.offset(extrusionWidth * infillOverlap / 100);
+    PointMatrix matrix(rotation);
+    outline.applyMatrix(matrix);
+    AABB boundary(outline);
+
+    // ignore infill for areas smaller than line spacing
+    if((abs(boundary.min.X - boundary.max.X) + abs(boundary.min.Y - boundary.max.Y)) < lineSpacing){
+      return;
+    }
+
+    // fix to normalise against diagonal infill
+    lineSpacing = lineSpacing * 2;
+
+    uint64_t Zscale = SQRT2MUL(lineSpacing);
+
+    int offset = abs(posZ % (Zscale) - (Zscale/2)) - (Zscale/4);
+    boundary.min.X = ((boundary.min.X / lineSpacing) - 1) * lineSpacing;
+    boundary.min.Y = ((boundary.min.Y / lineSpacing) - 1) * lineSpacing;
+
+    unsigned int lineCountX = (boundary.max.X - boundary.min.X + (lineSpacing - 1)) / lineSpacing;
+    unsigned int lineCountY = (boundary.max.Y - boundary.min.Y + (lineSpacing - 1)) / lineSpacing;
+    int rtMod = int(rotation / 90) % 2;
+    // with an odd number of lines, sides need to be swapped around
+    if(rtMod == 1){
+      rtMod = (lineCountX + int(rotation / 90)) % 2;
+    }
+
+    // draw non-horizontal walls of octohedrons
+    Polygons po;
+    PolygonRef p = po.newPoly();
+    for(unsigned int ly=0; ly < lineCountY;){
+      for(size_t it = 0; it < 2; ly++, it++){
+        int side = (2*((ly + it + rtMod) % 2) - 1);
+        int y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 - (offset/2 * side);
+        int x = boundary.min.X-(offset/2);
+        if(it == 1){
+          x = (lineCountX * (lineSpacing)) + boundary.min.X + lineSpacing / 2 - (offset/2);
+        }
+        p.add(Point(x,y));
+        for(unsigned int lx=0; lx < lineCountX; lx++){
+          if(it == 1){
+            side = (2*((lx + ly + it + rtMod + lineCountX) % 2) - 1);
+            y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 + (offset/2 * side);
+            x = ((lineCountX - lx - 1) * lineSpacing) + boundary.min.X + lineSpacing / 2;
+            p.add(Point(x+lineSpacing-abs(offset/2), y));
+            p.add(Point(x+abs(offset/2), y));
+          } else {
+            side = (2*((lx + ly + it + rtMod) % 2) - 1);
+            y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 + (offset/2 * side);
+            x = (lx * lineSpacing) + boundary.min.X + lineSpacing / 2;
+            p.add(Point(x+abs(offset/2), y));
+            p.add(Point(x+lineSpacing-abs(offset/2), y));
+          }
+        }
+        x = (lineCountX * lineSpacing) + boundary.min.X + lineSpacing / 2 - (offset/2);
+        if(it == 1){
+          x = boundary.min.X-(offset/2);
+        }
+        y = (ly * lineSpacing) + boundary.min.Y + lineSpacing / 2 - (offset/2 * side);
+        p.add(Point(x,y));
+      }
+    }
+    // Generate tops / bottoms of octohedrons
+    if(abs((abs(offset) - Zscale/4)) < (extrusionWidth/2)){
+      uint64_t startLine = (offset < 0) ? 0 : 1;
+      uint64_t coverWidth = OCTSLEN(lineSpacing);
+      vector<Point> points;
+      for(size_t xi = 0; xi < (lineCountX+1); xi++){
+        for(size_t yi = 0; yi < (lineCountY); yi += 2){
+          points.push_back(Point(boundary.min.X + OCTDLEN(lineSpacing)
+                                 + (xi - startLine + rtMod) * lineSpacing,
+                                 boundary.min.Y + OCTDLEN(lineSpacing)
+                                 + (yi + (xi%2)) * lineSpacing
+                                 + extrusionWidth/2));
+        }
+      }
+      uint64_t order = 0;
+      for(Point pp : points){
+        PolygonRef p = po.newPoly();
+        for(size_t yi = 0; yi <= coverWidth; yi += extrusionWidth) {
+          if(order == 0){
+            p.add(Point(pp.X, pp.Y + yi));
+            p.add(Point(pp.X + coverWidth + extrusionWidth, pp.Y + yi));
+          } else {
+            p.add(Point(pp.X + coverWidth + extrusionWidth, pp.Y + yi));
+            p.add(Point(pp.X, pp.Y + yi));
+          }
+          order = (order + 1) % 2;
+        }
+      }
+    }
+    // intersect with outline polygon(s)
+    Polygons pi = po.intersection(outline);
+    // Hack to add intersection to result. There doesn't seem
+    // to be a direct way to do this
+    for(unsigned int polyNr=0; polyNr < pi.size(); polyNr++) {
+      PolygonRef p = result.newPoly(); //  = result.newPoly()
+      for(unsigned int i=0; i < pi[polyNr].size(); i++) {
+        Point p0 = pi[polyNr][i];
+        p.add(matrix.unapply(Point(p0.X,p0.Y)));
+      }
     }
 }
 

--- a/src/infill.h
+++ b/src/infill.h
@@ -7,9 +7,10 @@
 namespace cura {
 
 void generateConcentricInfill(Polygons outline, Polygons& result, int inset_value);
-void generateAutomaticInfill(const Polygons& in_outline, Polygons& result, int extrusionWidth, int lineSpacing, int infillOverlap, double rotation);
+ void generateAutomaticInfill(const Polygons& in_outline, Polygons& result, int extrusionWidth, int lineSpacing, int infillOverlap, double rotation, int posZ);
 void generateGridInfill(const Polygons& in_outline, Polygons& result, int extrusionWidth, int lineSpacing, int infillOverlap, double rotation);
 void generateLineInfill(const Polygons& in_outline, Polygons& result, int extrusionWidth, int lineSpacing, int infillOverlap, double rotation);
+ void generateTroctInfill(const Polygons& in_outline, Polygons& result, int extrusionWidth, int lineSpacing, int infillOverlap, double rotation, int posZ);
 
 }//namespace cura
 


### PR DESCRIPTION
The truncated octohedron is a 3D space-filling honeycomb with no vertical walls. It has a near-optimal structure for surface area to volume (using identical filling cells), but has a somewhat simpler construction than the more efficient Weaire–Phelan structure. If this is coded correctly, then the structure should be composed of only regular squares and hexagons.

I figured it would be nice to put a truncated octohedron infill into Cura as well as Slic3r, given that my workplace (Malaghan Institute of Medical Research) is using Cura. The code as currently implemented traces over the "diagonal" walls every layer, and alternates between horizontal / vertical walls every second layer. This allows for internal paths creating the structure using only 45 degree turns, which should make it fairly fast to construct.

See the Slic3r issue for more details / history regarding how I came up with this code:
https://github.com/alexrj/Slic3r/issues/1646

Following on from a feature request in the Slic3r issue, I have capped off the tops of the truncated octahedrons with a Line infill, giving a bit more rigidity in the horizontal direction.
